### PR TITLE
pam: add realm_file option

### DIFF
--- a/README
+++ b/README
@@ -41,6 +41,7 @@ Config options to be set in the pam configuration:
         nosslhostnameverify
         nosslcertverify
         realm=<yourRealm>
+        realm_file=<perUserRealmFilename>
         resConf=<specialResolverConfig>
 
 

--- a/README.txt
+++ b/README.txt
@@ -41,6 +41,7 @@ Config options to be set in the pam configuration:
         nosslhostnameverify
         nosslcertverify
         realm=<yourRealm>
+        realm_file=<perUserRealmFilename>
         resConf=<specialResolverConfig>
 
 


### PR DESCRIPTION
Using the realm_file option it is possible to set the realm name on a per-user basis. An example setting would be
   realm_file=~/.otp_realm
or
   realm_file=/etc/linopt/%u.realm

We found ourselves in need of configuring different realms per account, and this was our solution, rather than prompting the user.